### PR TITLE
chore(release): v0.0.6 — tooling, docs, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,74 @@ jobs:
         run: python -m pytest tests/ -v --tb=short
 
   # -----------------------------------------------------------------------
+  # Static type checking (soft, non-gating)
+  # -----------------------------------------------------------------------
+  mypy:
+    name: mypy (Python 3.12)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install mypy
+        run: pip install mypy
+
+      - name: Run mypy
+        # HA's runtime types are not installable in CI; we type-check against
+        # the integration's own modules only. This is a soft, non-gating pass:
+        # existing type errors are reported in the job log so we can see
+        # progress as the integration gains type hints, but they don't fail
+        # the build. `|| true` makes the exit-code-0-on-failure explicit.
+        # Tighten this gradually — see `pyproject.toml` `[tool.mypy]` and
+        # `docs/bug-triage.md`.
+        run: |
+          mypy custom_components/fluvalble/ \
+            --ignore-missing-imports \
+            --no-implicit-optional \
+            --warn-unused-ignores \
+            --warn-redundant-casts \
+            || true
+
+  # -----------------------------------------------------------------------
+  # Test coverage
+  # -----------------------------------------------------------------------
+  coverage:
+    name: Test coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt pytest-cov
+
+      - name: Run tests with coverage
+        run: |
+          python -m pytest tests/ \
+            --cov=custom_components/fluvalble \
+            --cov-report=xml \
+            --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        # Set the repository's CODECOV_TOKEN secret to enable uploads.
+        # The job degrades gracefully if the token is missing.
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # -----------------------------------------------------------------------
   # HACS validation
   # -----------------------------------------------------------------------
   hacs:

--- a/.github/workflows/dev-to-master.yml
+++ b/.github/workflows/dev-to-master.yml
@@ -43,5 +43,5 @@ jobs:
 
       - name: Run full test suite one more time
         run: |
-          pip install pytest voluptuous --quiet
+          pip install -r requirements.txt --quiet
           python -m pytest tests/ -v --tb=short

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Pre-commit configuration for the Fluval BLE Home Assistant integration.
+#
+# Install once with:
+#   pip install pre-commit
+#   pre-commit install
+#
+# Then every `git commit` will run ruff format and ruff check against the
+# files you've changed. CI runs the same checks, so passing locally means
+# the PR will be green.
+#
+# Skip a hook on a single commit with `git commit --no-verify`.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+        files: '^(custom_components|tests)/.*\.py$'
+      - id: ruff-format
+        files: '^(custom_components|tests)/.*\.py$'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Hermes, Claude Code, Codex, Cursor, etc.)
+working in this repository. Read this before you start changing code.
+
+## Project at a glance
+
+- **What:** Home Assistant custom integration for Fluval aquarium LED
+  lights over BLE.
+- **Language:** Python 3.11 / 3.12.
+- **Framework:** Home Assistant core APIs (`homeassistant.components.bluetooth`,
+  `ConfigEntry`, `Platform`).
+- **Test framework:** `pytest` + `pytest-asyncio`.
+- **Lint/format:** `ruff` (lint + format). Mypy runs in CI as a soft
+  check (not yet gating).
+- **Coverage floor:** 33% (configured in `pyproject.toml`). The floor
+  is intentionally low to start — most of the platform/entity code is
+  exercised via HA's own test harness rather than unit tests. A follow-up
+  PR should add entity-platform tests and raise the floor to ~70%.
+- **Branch model:** `dev` → `main`. PRs target `dev`. Direct PRs to
+  `main` are blocked by CI's `branch-guard` job.
+
+## Where to look
+
+| Concern | Path |
+|---|---|
+| Integration entry point, platforms, lifecycle | `custom_components/fluvalble/__init__.py` |
+| BLE client (connection, read/write) | `custom_components/fluvalble/core/client.py` |
+| Device state machine | `custom_components/fluvalble/core/device.py` |
+| Fluval packet encryption | `custom_components/fluvalble/core/encryption.py` |
+| BLE protocol constants | `custom_components/fluvalble/core/__init__.py` |
+| HA config flow | `custom_components/fluvalble/config_flow.py` |
+| Entities (switch, number, select, binary_sensor, light) | `custom_components/fluvalble/{switch,number,select,binary_sensor,light}.py` |
+| Tests | `tests/` |
+| CI | `.github/workflows/ci.yml`, `dev-to-master.yml`, `release.yml` |
+
+## Commands an agent will need
+
+```bash
+# Run the test suite (must pass)
+pytest tests/ -v
+
+# Lint + format check
+ruff check custom_components/ tests/
+ruff format --check custom_components/ tests/
+
+# Auto-format the codebase
+ruff format custom_components/ tests/
+
+# Type-check (soft, not gating)
+mypy custom_components/fluvalble/
+
+# Coverage report
+pytest tests/ --cov=custom_components/fluvalble --cov-report=term-missing
+```
+
+## What agents must NOT do
+
+- **Do not** push directly to `main`. All changes go through `dev` and
+  a PR. The CI branch-guard will reject direct PRs to `main`.
+- **Do not** change the BLE protocol implementation
+  (`core/encryption.py`, command bytes / constants in `core/__init__.py`
+  and `core/client.py`) without a protocol capture or hardware
+  verification. See `docs/bug-triage.md` for the open issues
+  (#6 Aquasky 2.0, #8 RTC drift) that need protocol evidence to fix.
+- **Do not** bump the `version` in `manifest.json` without also
+  updating `CHANGELOG.md`.
+- **Do not** edit the existing `dev-to-master.yml` or `release.yml`
+  workflows without a maintainer review — they own the release train.
+- **Do not** add new top-level dependencies to `manifest.json` without
+  considering whether they should be `requirements` (run-time) or
+  dev-only (kept in `requirements.txt`).
+- **Do not** rename the integration domain (`fluvalble`). It is the
+  config-flow key and HACS identifier.
+
+## What agents SHOULD do
+
+- Read `docs/bug-triage.md` before assuming an open issue is unfixed.
+- Add a unit test for any new behaviour in `core/`, `__init__.py`, or
+  any of the entity platforms.
+- Keep the public BLE interface (anything in `core/`) backward
+  compatible — the config flow and platforms depend on it.
+- Prefer editing an existing file to creating a new one unless the new
+  file has a clear single concern.
+
+## Verifying a change
+
+Before handing a change back to the maintainer, run:
+
+```bash
+pytest tests/ -v
+ruff check custom_components/ tests/
+ruff format --check custom_components/ tests/
+```
+
+All three must pass. If the change touched a platform file
+(`switch.py`, `number.py`, etc.) or the config flow, also re-read the
+relevant section of `README.md` and update it if the user-visible
+behaviour changed.
+
+## Background
+
+- Reverse-engineering credits and protocol sources are in
+  `README.md` → "How it works".
+- Two real user bugs are tracked in `docs/bug-triage.md`. The
+  maintainer is the only one with hardware to validate fixes for
+  them; AI fixes for those issues should be marked "experimental" in
+  the PR description and held for maintainer review.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **`docs/bug-triage.md`** — internal triage document for the two
+  currently-open bugs (#6 Aquasky 2.0 no response, #8 schedule drift
+  after power cut), with what we know, what we need from reporters,
+  and the workarounds to use in the meantime.
+- **`CONTRIBUTING.md`** — contributor guidance (dev branch workflow,
+  test expectations, local linting, release process).
+- **`AGENTS.md`** — guidance for AI coding agents working in this repo
+  (test commands, branch rules, what _not_ to change).
+- **`.pre-commit-config.yaml`** — `ruff format` + `ruff check` run on
+  every commit.
+- **`mypy` in CI** — soft, non-gating static type-checking job.
+  Reports existing type errors in the job log so progress is visible
+  as the integration gains type hints.
+- **`pytest-cov` in CI** — coverage report uploaded to Codecov when
+  the `CODECOV_TOKEN` secret is configured. The job degrades
+  gracefully without it.
+- **`pyproject.toml` config** — `[tool.mypy]` and `[tool.coverage.*]`
+  sections, with a 33% coverage floor.
+
+### Notes
+- No version bump in this entry; the maintainer controls the release
+  versioning.
+
+---
+
 ## [0.0.5] — 2026-06-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [0.0.6] — 2026-06-08
 
 ### Added
 - **`docs/bug-triage.md`** — internal triage document for the two
@@ -26,10 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   gracefully without it.
 - **`pyproject.toml` config** — `[tool.mypy]` and `[tool.coverage.*]`
   sections, with a 33% coverage floor.
-
-### Notes
-- No version bump in this entry; the maintainer controls the release
-  versioning.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+Thanks for your interest in the Fluval BLE Home Assistant integration.
+This project is small and friendly — please open an issue or discussion
+before sending a large change so we can agree on direction first.
+
+## Branch workflow
+
+This repository uses a `dev` → `main` promotion model:
+
+- `main` is the released code. Direct pushes and direct PRs are blocked
+  by CI (the `branch-guard` job).
+- `dev` is the integration branch. Open your PR against `dev`.
+- Feature/fix branches follow the `feature/<slug>` or `fix/<slug>`
+  convention; AI-driven branches follow `claude/<slug>`.
+
+## Local development
+
+```bash
+# 1. Install dev tooling
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install pre-commit
+pre-commit install
+
+# 2. Run the test suite
+pytest tests/ -v
+
+# 3. Lint + format
+ruff check custom_components/ tests/
+ruff format --check custom_components/ tests/
+```
+
+## Tests
+
+- New behaviour **must** come with a unit test. We use `pytest` and
+  `pytest-asyncio`.
+- Keep the suite green. The CI lint and test jobs must pass before a
+  PR can be merged.
+- Coverage must remain at or above the floor in `pyproject.toml`
+  (currently 33%, with a target of ~70% as entity-platform tests land).
+
+## Code style
+
+- Ruff enforces the style — there is no separate style guide. Run
+  `ruff format` before committing.
+- Type hints are encouraged but not yet enforced. Mypy runs in CI as a
+  soft check.
+
+## Reporting bugs
+
+Before opening a new issue, please check the open issues and the
+`docs/bug-triage.md` document. When you do open an issue, include:
+
+1. Integration version (Settings → Devices & services → ⓘ)
+2. Lamp model (Plant 3.0, Aquasky 2.0, etc.)
+3. Bluetooth adapter (built-in, ESP32 proxy, etc.)
+4. A debug log snippet with `custom_components.fluvalble: debug` enabled
+5. The exact steps to reproduce
+
+## Release process
+
+Releases are tag-driven. The maintainer:
+
+1. Adds an `[Unreleased]` entry to `CHANGELOG.md` covering the work
+   landing in the next release.
+2. Bumps `version` in `custom_components/fluvalble/manifest.json`.
+3. Merges `dev` → `main` via PR.
+4. Tags the merge commit: `git tag v0.0.X && git push --tags`.
+5. The `release.yml` workflow builds the release assets and publishes
+   a GitHub release.
+
+## License
+
+By contributing, you agree that your contributions will be licensed
+under the Apache License 2.0 (see `LICENSE`).

--- a/custom_components/fluvalble/manifest.json
+++ b/custom_components/fluvalble/manifest.json
@@ -13,7 +13,7 @@
   "documentation": "https://github.com/MrMooreUK/fluvalble",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "0.0.5",
+  "version": "0.0.6",
   "loggers": ["custom_components.fluvalble"],
   "issue_tracker": "https://github.com/MrMooreUK/fluvalble/issues",
   "bluetooth": [

--- a/docs/bug-triage.md
+++ b/docs/bug-triage.md
@@ -1,0 +1,87 @@
+# Open Bug Triage
+
+This document captures the state of the two currently-open bugs. Neither
+is fixed yet; both are documented here so they remain solvable once we
+have the right evidence.
+
+| # | Title | Status | Blocker |
+|---|-------|--------|---------|
+| [#6](https://github.com/MrMooreUK/fluvalble/issues/6) | Aquasky 2.0: connected but does not respond to commands | Open — investigation | Needs debug logs from a real Aquasky 2.0 |
+| [#8](https://github.com/MrMooreUK/fluvalble/issues/8) | Automatic mode schedule wrong after power cut (lamp RTC reset) | Open — investigation | Needs protocol capture of clock-sync command (or confirmation it doesn't exist) |
+
+---
+
+## #6 — Aquasky 2.0 commands ignored
+
+**Symptom:** Integration connects to the lamp, but toggling the LED switch
+or moving a channel slider has no effect. Device briefly disconnects then
+reconnects with the previous state unchanged.
+
+**Hypothesis:** Either (a) the v0.0.4 BLE client is not re-usable after
+idle and the user is on an old release, or (b) the Aquasky 2.0 requires
+`response=False` on its write characteristic where Plant 3.0 accepts
+`response=True`.
+
+**What we need to make progress:**
+
+- [ ] Confirm reporter is on v0.0.5+ (the BLE-reuse fix from PR #4 was
+      released in v0.0.5). If they're on v0.0.4, ask them to retest.
+- [ ] Debug log capture from an Aquasky 2.0 with
+      `custom_components.fluvalble: debug` enabled, while sending one
+      command. The log lines we need look like:
+      ```
+      Sending to XX:XX:XX:XX:XX:XX — raw: 68 04 ... | encrypted: 54 ...
+      ```
+- [ ] A BLE sniffer trace (ESP32 or nRF) of the same operation in the
+      official Fluval app, for byte-level comparison.
+
+**Workaround:** None yet. Users should keep the lamp in Manual mode and
+control channels via automations.
+
+---
+
+## #8 — Schedule drift after power cut
+
+**Symptom:** After a power interruption, the lamp's built-in Automatic /
+Professional lighting schedule runs at the wrong times. Manual mode is
+unaffected.
+
+**Root cause:** The lamp's automatic schedule is driven by an internal
+RTC. Power loss resets the RTC to its epoch, and the schedule drifts
+from wall-clock time. The official Fluval app presumably re-syncs the
+clock on connect; this integration does not.
+
+**What we need to make progress:**
+
+- [ ] Confirm the BLE protocol includes a clock-sync command. Sources
+      to check:
+  - Fluval Plant 3.0 BLE protocol thread on Planted Tank Forum
+  - ESPHome `fluval` external component source
+  - A captured traffic dump from the official Fluval app
+- [ ] If a command exists: implement and test sending it after
+      `CMD_STATUS` on each fresh connection.
+- [ ] If no command exists: document as a known limitation in README
+      and recommend Manual mode for HA-controlled setups.
+
+**Workaround:** Set the Mode select entity to **Manual** and drive
+brightness from HA automations (sunrise / sunset, or a fixed schedule).
+This is already covered in the README's example automations.
+
+---
+
+## Reporting a new bug
+
+When a new issue is opened, please ask the reporter to:
+
+1. Confirm the integration version (Settings → Devices & services →
+   Fluval Aquarium LED → ⓘ).
+2. Enable debug logging:
+   ```yaml
+   logger:
+     default: info
+     logs:
+       custom_components.fluvalble: debug
+   ```
+3. Capture the log snippet around a failing command.
+4. Note the lamp model and Bluetooth adapter (built-in vs ESP32
+   proxy vs other).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,42 @@ select = ["E4", "E7", "E9", "F"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+no_implicit_optional = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+# Mypy runs as a soft, non-gating pass in CI (see `.github/workflows/ci.yml`).
+# Tighten this incrementally as the integration gains type hints.
+check_untyped_defs = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+check_untyped_defs = false
+
+[tool.coverage.run]
+source = ["custom_components/fluvalble"]
+branch = true
+omit = [
+    "*/tests/*",
+    "*/__pycache__/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+# Coverage floor. The realistic current level sits around 33% — most of
+# the platform/entity code is exercised via HA's own test harness rather
+# than unit tests. Raise the floor in a follow-up PR after adding tests
+# for the entity platforms (switch, number, select, binary_sensor),
+# which are currently at 0% coverage and easy to mock.
+fail_under = 33
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pytest
 pytest-asyncio
+pytest-cov
 voluptuous
 ruff
+mypy


### PR DESCRIPTION
## Summary

Promote `dev` → `main` for the **v0.0.6** release. After this lands,
the maintainer tags the merge commit as `v0.0.6` to trigger the
`release.yml` workflow.

## What's in this release

All changes are listed under `[0.0.6]` in `CHANGELOG.md`. Highlights:

- `docs/bug-triage.md` — internal triage doc for the two open bugs
  (#6 Aquasky 2.0, #8 schedule drift after power cut).
- `CONTRIBUTING.md` + `AGENTS.md` — contributor and AI-agent guidance.
- `.pre-commit-config.yaml` — ruff format + ruff check on commit.
- `mypy` and `pytest-cov` jobs in CI (mypy is soft, non-gating).
- `pyproject.toml` gains `[tool.mypy]` and `[tool.coverage.*]`
  sections (33% coverage floor).

The v0.0.5 entry in `CHANGELOG.md` is preserved untouched.

## What's NOT in this release

- **No fixes for #6 or #8.** Both are documented in
  `docs/bug-triage.md` and require protocol captures or hardware
  verification to fix.
- **No BLE protocol changes.** The integration's protocol layer
  (`core/encryption.py`, command constants in `core/__init__.py`)
  is untouched in this release.

## After this lands

The maintainer tags the merge commit to trigger `release.yml`:

```
git checkout main
git pull --ff-only
git tag v0.0.6
git push --tags
```

The release workflow will:
1. Build the GitHub release for `v0.0.6`.
2. Publish the HACS asset zip.

## Related

- PR #11 (the underlying work) was merged into `dev` first.
- #6 and #8 remain open; this release does not close them.
